### PR TITLE
Add CLI subcommands to govpilot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,43 @@
-struct Cli {}
+use clap::{Parser, Subcommand};
 
-fn main() {}
+#[derive(Parser)]
+#[command(name = "govpilot", about = "A CLI for government innovation.", version = "0.1.0")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Hello,
+    Joke,
+    Fact,
+    Art,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Hello => hello(),
+        Commands::Joke => joke(),
+        Commands::Fact => fact(),
+        Commands::Art => art(),
+    }
+}
+
+fn hello() {
+    println!("Hello from govpilot!");
+}
+
+fn joke() {
+    println!("Here's a government joke for you!");
+}
+
+fn fact() {
+    println!("Did you know? Here's a government fact.");
+}
+
+fn art() {
+    println!("Displaying government art.");
+}


### PR DESCRIPTION
Related to #1

Implements the initial scaffolding for the `govpilot` CLI application using the Clap crate, introducing four subcommands as requested.

- **Integrates Clap crate** for command-line parsing, utilizing the derive syntax for cleaner code structure.
- **Defines subcommands** `hello`, `joke`, `fact`, and `art` within the `Cli` struct, enabling the application to recognize and respond to these commands.
- **Implements placeholder functions** for each subcommand, providing a basic response when each command is invoked.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anweiss/gov-inno-copilot-demo/issues/1?shareId=59340779-d6ab-4eae-8b56-2ca49fab5dc6).