### PR TITLE
Fetch random dad joke for joke subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2021"
 artem = "3.0.0"
 clap = { version = "4.5.4", features = ["derive"] }
 image = "0.25.1"
+reqwest = "0.11"
+tokio = { version = "1", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use clap::{Parser, Subcommand};
+use reqwest;
+use tokio;
 
 #[derive(Parser)]
 #[command(name = "govpilot", about = "A CLI for government innovation.", version = "0.1.0")]
@@ -15,12 +17,13 @@ enum Commands {
     Art,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Hello => hello(),
-        Commands::Joke => joke(),
+        Commands::Joke => joke().await,
         Commands::Fact => fact(),
         Commands::Art => art(),
     }
@@ -30,8 +33,21 @@ fn hello() {
     println!("Hello from govpilot!");
 }
 
-fn joke() {
-    println!("Here's a government joke for you!");
+async fn joke() {
+    let url = "https://icanhazdadjoke.com/";
+    let client = reqwest::Client::new();
+    let res = client.get(url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    if res.status().is_success() {
+        let joke = res.json::<Joke>().await.expect("Failed to parse joke");
+        println!("{}", joke.joke);
+    } else {
+        println!("Failed to fetch joke");
+    }
 }
 
 fn fact() {
@@ -40,4 +56,9 @@ fn fact() {
 
 fn art() {
     println!("Displaying government art.");
+}
+
+#[derive(serde::Deserialize)]
+struct Joke {
+    joke: String,
 }


### PR DESCRIPTION
Related to #5

Implements the `joke` subcommand to fetch and display a random joke from the dad jokes API.

- **Dependencies Added**: Adds `reqwest` and `tokio` to `Cargo.toml` for making HTTP requests and supporting asynchronous execution.
- **Async Execution**: Updates the `main` function in `src/main.rs` to use `tokio::main` attribute, enabling asynchronous execution.
- **Joke Fetching**: Modifies the `joke` function to asynchronously fetch a random joke from "https://icanhazdadjoke.com/" using the `reqwest` client. It sends a GET request with the "Accept: application/json" header, parses the JSON response into a `Joke` struct, and prints the joke to stdout.
- **Error Handling**: Implements basic error handling for HTTP request failure and JSON parsing failure, printing error messages to stdout.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anweiss/gov-inno-copilot-demo/issues/5?shareId=3d39e253-4bbe-445e-8f3d-cac5bda39572).