### PR TITLE
Implement art subcommand functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, Arg};
 use reqwest;
 use tokio;
+use artem::{self, config::ConfigBuilder};
+use image::open;
 
 #[derive(Parser)]
 #[command(name = "govpilot", about = "A CLI for government innovation.", version = "0.1.0")]
@@ -14,7 +16,10 @@ enum Commands {
     Hello,
     Joke,
     Fact,
-    Art,
+    Art {
+        #[arg(short, long)]
+        path: String,
+    },
 }
 
 #[tokio::main]
@@ -25,7 +30,7 @@ async fn main() {
         Commands::Hello => hello(),
         Commands::Joke => joke().await,
         Commands::Fact => fact(),
-        Commands::Art => art(),
+        Commands::Art { path } => art(&path).await,
     }
 }
 
@@ -54,8 +59,16 @@ fn fact() {
     println!("Did you know? Here's a government fact.");
 }
 
-fn art() {
-    println!("Displaying government art.");
+async fn art(path: &str) {
+    let image = match open(path) {
+        Ok(img) => img,
+        Err(e) => {
+            println!("Failed to open image: {}", e);
+            return;
+        }
+    };
+    let ascii_art = artem::convert(image, &ConfigBuilder::new().build());
+    println!("{}", ascii_art);
 }
 
 #[derive(serde::Deserialize)]


### PR DESCRIPTION
Related to #8

Implements the `art` subcommand to allow passing a .png image path and printing an ASCII art equivalent to stdout using the `artem` and `image` crates.

- **Subcommand Update**: Adds a variant for `Art` in the `Commands` enum that accepts a file path argument, enabling the `art` subcommand to process a `.png` image path.
- **Argument Parsing**: Implements argument parsing for the `Art` command to accept and handle a `.png` image path.
- **Image Processing and ASCII Art Conversion**: Updates the `art` function to open the specified image file, convert it to ASCII art using the `artem` and `image` crates, and print the result to stdout. Includes error handling for file opening.
- **Async Functionality**: Modifies the `art` function to be asynchronous, aligning with the async nature of the main function and other command functions.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/anweiss/gov-inno-copilot-demo/issues/8?shareId=ccbbe1fd-506f-47c0-9b25-1512d13446a5).